### PR TITLE
Remove Redis integration

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,3 @@ numpy>=1.26.0
 httpx>=0.27.0
 pytest>=8.2.0
 requests==2.31.0
-redis==5.0.4


### PR DESCRIPTION
## Summary
- drop the optional Redis client and helpers from the FastAPI service
- keep refresh-token rotation entirely in-process and update status/execute checks
- remove the Redis dependency from the requirements list

## Testing
- `PYTHONPATH=. pytest` *(fails: TypeError: ForwardRef._evaluate() missing 1 required keyword-only argument: 'recursive_guard')*

------
https://chatgpt.com/codex/tasks/task_e_68c9518548d0832f999e03707315d7af