### PR TITLE
Add Telegram Saxo login flow with OAuth callback

### DIFF
--- a/app/telegram_login.py
+++ b/app/telegram_login.py
@@ -1,0 +1,214 @@
+"""Telegram webhook + Saxo OAuth helper.
+
+Dit module verzorgt de state-handling voor de Telegram-logincommandos
+en de uitwisseling van de authorization code naar een (refresh) token.
+
+Alles is bewust synchrone code zodat het zowel in tests als in FastAPI
+endpoints eenvoudig aan te roepen is. Netwerkfouten worden gelogd maar
+breken het proces niet – de FastAPI-routes geven in dat geval een
+vriendelijke melding terug aan de gebruiker via Telegram én HTTP.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import secrets
+import threading
+import time
+from dataclasses import dataclass
+from typing import Dict, Optional, Set
+from urllib.parse import urlencode
+
+import httpx
+
+log = logging.getLogger("telegram")
+
+
+@dataclass
+class PendingLogin:
+    """Gegevens voor een lopende Saxo-login via Telegram."""
+
+    state: str
+    chat_id: int
+    created_at: float
+    expires_at: float
+    first_name: str = ""
+    username: Optional[str] = None
+
+
+class LoginError(RuntimeError):
+    """Fout bij het opzetten of afronden van de login-flow."""
+
+
+def _parse_chat_ids(raw: str) -> Set[int]:
+    ids: Set[int] = set()
+    if not raw:
+        return ids
+    for part in raw.replace(";", ",").split(","):
+        part = part.strip()
+        if not part:
+            continue
+        try:
+            ids.add(int(part))
+        except ValueError:
+            log.warning("TG_ALLOWED_CHAT_IDS: '%s' is geen geldig integer id", part)
+    return ids
+
+
+class TelegramLoginManager:
+    """Beheert Telegram-commando's en Saxo OAuth state."""
+
+    def __init__(self) -> None:
+        self._states: Dict[str, PendingLogin] = {}
+        self._lock = threading.Lock()
+        self.reload()
+
+    # ------------------------------------------------------------------
+    # Config laden
+    # ------------------------------------------------------------------
+    def reload(self) -> None:
+        self.enabled = os.getenv("TG_ENABLED", "false").lower() == "true"
+        self.bot_token = os.getenv("TG_BOT_TOKEN", "").strip()
+        self.api_base = (
+            f"https://api.telegram.org/bot{self.bot_token}" if self.bot_token else ""
+        )
+        self.webhook_secret = os.getenv("TG_WEBHOOK_SECRET", "").strip()
+        self.allowed_chat_ids: Set[int] = _parse_chat_ids(os.getenv("TG_ALLOWED_CHAT_IDS", ""))
+
+        fallback_chat = os.getenv("TG_CHAT_ID", "").strip()
+        if fallback_chat:
+            try:
+                self.allowed_chat_ids.add(int(fallback_chat))
+            except ValueError:
+                log.warning("TG_CHAT_ID is geen integer: %s", fallback_chat)
+
+        try:
+            self.state_ttl = int(os.getenv("SAXO_LOGIN_STATE_TTL", "600"))
+        except ValueError:
+            self.state_ttl = 600
+
+        self.app_key = os.getenv("SAXO_APP_KEY", "").strip()
+        self.app_secret = os.getenv("SAXO_APP_SECRET", "").strip()
+        self.token_url = os.getenv("SAXO_TOKEN_URL", "https://sim.logonvalidation.net/token").strip()
+        self.auth_url = os.getenv("SAXO_AUTH_URL", "https://sim.logonvalidation.net/authorize").strip()
+        self.redirect_url = os.getenv("SAXO_REDIRECT_URL", "").strip()
+        self.scope = os.getenv("SAXO_AUTH_SCOPE", "offline_access trading").strip()
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+    def is_enabled(self) -> bool:
+        return self.enabled and bool(self.bot_token)
+
+    def is_chat_allowed(self, chat_id: int) -> bool:
+        return not self.allowed_chat_ids or chat_id in self.allowed_chat_ids
+
+    def _cleanup_locked(self, now: Optional[float] = None) -> None:
+        now = now or time.time()
+        expired = [
+            state
+            for state, info in self._states.items()
+            if info.expires_at and info.expires_at < now
+        ]
+        for state in expired:
+            self._states.pop(state, None)
+
+    # ------------------------------------------------------------------
+    # State management
+    # ------------------------------------------------------------------
+    def create_login_request(
+        self, chat_id: int, *, first_name: str = "", username: Optional[str] = None
+    ) -> PendingLogin:
+        if not self.is_enabled():
+            raise LoginError("Telegram bot niet geconfigureerd (TG_ENABLED/TG_BOT_TOKEN).")
+        if not self.app_key:
+            raise LoginError("SAXO_APP_KEY ontbreekt.")
+        if not self.redirect_url:
+            raise LoginError("SAXO_REDIRECT_URL ontbreekt.")
+
+        now = time.time()
+        state = secrets.token_urlsafe(32)
+        ttl = max(60, int(self.state_ttl))
+        pending = PendingLogin(
+            state=state,
+            chat_id=int(chat_id),
+            created_at=now,
+            expires_at=now + ttl,
+            first_name=first_name or "",
+            username=username,
+        )
+        with self._lock:
+            self._cleanup_locked(now)
+            self._states[state] = pending
+        return pending
+
+    def consume_state(self, state: str) -> Optional[PendingLogin]:
+        if not state:
+            return None
+        with self._lock:
+            info = self._states.pop(state, None)
+        if not info:
+            return None
+        if info.expires_at and info.expires_at < time.time():
+            return None
+        return info
+
+    # ------------------------------------------------------------------
+    # Telegram en OAuth interacties
+    # ------------------------------------------------------------------
+    def build_authorize_url(self, pending: PendingLogin) -> str:
+        params = {
+            "response_type": "code",
+            "client_id": self.app_key,
+            "redirect_uri": self.redirect_url,
+            "state": pending.state,
+        }
+        if self.scope:
+            params["scope"] = self.scope
+        return f"{self.auth_url}?{urlencode(params)}"
+
+    def send_message(self, chat_id: int, text: str) -> None:
+        if not self.is_enabled():
+            return
+        url = f"{self.api_base}/sendMessage"
+        payload = {
+            "chat_id": int(chat_id),
+            "text": text,
+            "disable_web_page_preview": True,
+        }
+        try:
+            httpx.post(url, json=payload, timeout=10.0)
+        except Exception as exc:  # pragma: no cover - logging
+            log.warning("Telegram sendMessage failed: %s", exc)
+
+    def exchange_code_for_tokens(self, code: str) -> dict:
+        if not self.app_key or not self.app_secret:
+            raise LoginError("SAXO_APP_KEY of SAXO_APP_SECRET ontbreekt.")
+        if not self.redirect_url:
+            raise LoginError("SAXO_REDIRECT_URL ontbreekt.")
+        data = {
+            "grant_type": "authorization_code",
+            "code": code,
+            "redirect_uri": self.redirect_url,
+            "client_id": self.app_key,
+            "client_secret": self.app_secret,
+        }
+        try:
+            resp = httpx.post(self.token_url, data=data, timeout=20.0)
+        except Exception as exc:  # pragma: no cover - netwerkfout
+            raise LoginError(f"Verbinding met Saxo token endpoint faalde: {exc}") from exc
+
+        if resp.status_code not in (200, 201):
+            raise LoginError(
+                f"Token endpoint gaf status {resp.status_code}: {resp.text[:400]}"
+            )
+        try:
+            return resp.json()
+        except Exception as exc:  # pragma: no cover - JSON fout
+            raise LoginError(f"Kon token-response niet parsen: {resp.text[:400]}") from exc
+
+
+# Singleton manager voor gebruik in de FastAPI-app
+manager = TelegramLoginManager()
+

--- a/render.yaml
+++ b/render.yaml
@@ -19,3 +19,15 @@ services:
         sync: false
       - key: TG_CHAT_ID
         sync: false
+      - key: TG_WEBHOOK_SECRET
+        sync: false
+      - key: TG_ALLOWED_CHAT_IDS
+        sync: false
+      - key: SAXO_REDIRECT_URL
+        sync: false
+      - key: SAXO_AUTH_URL
+        value: https://sim.logonvalidation.net/authorize
+      - key: SAXO_AUTH_SCOPE
+        value: "offline_access trading"
+      - key: SAXO_LOGIN_STATE_TTL
+        value: "600"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 fastapi==0.103.2
 uvicorn[standard]==0.23.2
-pydantic==1.10.13
+pydantic==1.10.17
 python-dateutil>=2.9.0.post0
 numpy>=1.26.0
-httpx>=0.27.0
+httpx==0.27.2
 pytest>=8.2.0
 requests==2.31.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_decide.py
+++ b/tests/test_decide.py
@@ -1,3 +1,7 @@
+import os
+
+os.environ["SINGLE_API_KEY"] = ""
+
 from app.main import app
 from fastapi.testclient import TestClient
 

--- a/tests/test_telegram_login.py
+++ b/tests/test_telegram_login.py
@@ -1,0 +1,121 @@
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.telegram_login import manager as tg_manager
+
+
+def _build_update(chat_id: int, text: str = "/saxo_login") -> dict:
+    return {
+        "update_id": 1,
+        "message": {
+            "message_id": 99,
+            "date": 1700000000,
+            "chat": {"id": chat_id, "type": "private"},
+            "from": {"id": 4242, "first_name": "Test", "username": "tester"},
+            "text": text,
+        },
+    }
+
+
+def test_telegram_webhook_disabled(monkeypatch):
+    monkeypatch.setenv("TG_ENABLED", "false")
+    monkeypatch.setenv("TG_BOT_TOKEN", "")
+    tg_manager.reload()
+    tg_manager._states.clear()
+
+    with TestClient(app) as client:
+        res = client.post("/telegram/webhook", json={"update_id": 1})
+    assert res.status_code == 200
+    assert res.json()["reason"] == "telegram_disabled"
+
+
+def test_telegram_webhook_requires_secret(monkeypatch):
+    monkeypatch.setenv("TG_ENABLED", "true")
+    monkeypatch.setenv("TG_BOT_TOKEN", "dummy")
+    monkeypatch.setenv("TG_CHAT_ID", "123")
+    monkeypatch.setenv("TG_WEBHOOK_SECRET", "expected")
+    monkeypatch.setenv("SAXO_APP_KEY", "abc")
+    monkeypatch.setenv("SAXO_REDIRECT_URL", "https://example.com/oauth")
+    tg_manager.reload()
+    tg_manager._states.clear()
+
+    update = _build_update(123)
+    with TestClient(app) as client:
+        res = client.post(
+            "/telegram/webhook",
+            json=update,
+            headers={"X-Telegram-Bot-Api-Secret-Token": "wrong"},
+        )
+    assert res.status_code == 401
+
+
+def test_telegram_login_command(monkeypatch):
+    monkeypatch.setenv("TG_ENABLED", "true")
+    monkeypatch.setenv("TG_BOT_TOKEN", "dummy")
+    monkeypatch.setenv("TG_CHAT_ID", "123")
+    monkeypatch.setenv("TG_WEBHOOK_SECRET", "")
+    monkeypatch.setenv("SAXO_APP_KEY", "abc")
+    monkeypatch.setenv("SAXO_REDIRECT_URL", "https://example.com/oauth")
+    monkeypatch.setenv("SAXO_AUTH_URL", "https://sim.logonvalidation.net/authorize")
+    tg_manager.reload()
+    tg_manager._states.clear()
+
+    captured = []
+
+    def fake_send(chat_id: int, text: str) -> None:
+        captured.append((chat_id, text))
+
+    monkeypatch.setattr(tg_manager, "send_message", fake_send)
+
+    update = _build_update(123)
+    with TestClient(app) as client:
+        res = client.post("/telegram/webhook", json=update)
+
+    data = res.json()
+    assert res.status_code == 200
+    assert data["action"] == "login_link_sent"
+    state = data["state"]
+    assert state in tg_manager._states
+    assert captured and captured[0][0] == 123
+    assert "https://sim.logonvalidation.net/authorize" in captured[0][1]
+    assert state in captured[0][1]
+
+
+def test_telegram_callback_success(monkeypatch):
+    monkeypatch.setenv("TG_ENABLED", "true")
+    monkeypatch.setenv("TG_BOT_TOKEN", "dummy")
+    monkeypatch.setenv("TG_CHAT_ID", "123")
+    monkeypatch.setenv("SAXO_APP_KEY", "abc")
+    monkeypatch.setenv("SAXO_APP_SECRET", "secret")
+    monkeypatch.setenv("SAXO_REDIRECT_URL", "https://example.com/oauth")
+    tg_manager.reload()
+    tg_manager._states.clear()
+
+    pending = tg_manager.create_login_request(123, first_name="Tester")
+
+    captured = []
+
+    def fake_send(chat_id: int, text: str) -> None:
+        captured.append((chat_id, text))
+
+    monkeypatch.setattr(tg_manager, "send_message", fake_send)
+
+    def fake_exchange(code: str) -> dict:
+        assert code == "auth-code"
+        return {"refresh_token": "REFRESH-XYZ123", "expires_in": 480}
+
+    monkeypatch.setattr(tg_manager, "exchange_code_for_tokens", fake_exchange)
+
+    with TestClient(app) as client:
+        res = client.get(
+            "/oauth/saxo/telegram/callback", params={"state": pending.state, "code": "auth-code"}
+        )
+
+    assert res.status_code == 200
+    assert "Laatste 6 tekens" in res.text
+    assert pending.state not in tg_manager._states
+    assert any("REFRESH-XYZ123" in msg for _, msg in captured)
+
+    from app import main as main_module
+
+    assert main_module._stored_refresh_token == "REFRESH-XYZ123"


### PR DESCRIPTION
## Summary
- add a Telegram login manager to issue Saxo OAuth authorization links and keep temporary state for refresh-token retrieval
- expose `/telegram/webhook` and `/oauth/saxo/telegram/callback` endpoints that validate chat permissions, exchange authorization codes, and send the resulting refresh token back to Telegram
- document the new environment variables, pin compatible dependency versions, and expand the test-suite for Telegram and API-key flows

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb0d0fc73c832f92fc9cdc73631400