### PR TITLE
Allow /login_saxo alias for Telegram login command

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -348,7 +348,7 @@ async def telegram_webhook(
     command = command_raw.split("@", 1)[0]
     user = message.get("from") or {}
 
-    if command == "/saxo_login":
+    if command in {"/saxo_login", "/login_saxo"}:
         try:
             pending = telegram_login_manager.create_login_request(
                 chat_id,
@@ -376,12 +376,14 @@ async def telegram_webhook(
     if command in ("/start", "/help"):
         telegram_login_manager.send_message(
             chat_id,
-            "Beschikbare commando's:\n/saxo_login – vraag een nieuwe Saxo refresh token aan.",
+            "Beschikbare commando's:\n"
+            "/saxo_login – vraag een nieuwe Saxo refresh token aan. (/login_saxo werkt ook)",
         )
         return {"ok": True, "action": "help_sent"}
 
     telegram_login_manager.send_message(
-        chat_id, "Onbekend commando. Gebruik /saxo_login voor Saxo OAuth."
+        chat_id,
+        "Onbekend commando. Gebruik /saxo_login (of /login_saxo) voor Saxo OAuth.",
     )
     return {"ok": True, "action": "unknown_command"}
 
@@ -397,7 +399,7 @@ def telegram_oauth_callback(
     if not info:
         return HTMLResponse(
             "<html><body><h1>State ongeldig of verlopen</h1>"
-            "<p>Vraag een nieuwe login aan via Telegram (/saxo_login).</p></body></html>",
+            "<p>Vraag een nieuwe login aan via Telegram (/saxo_login of /login_saxo).</p></body></html>",
             status_code=400,
         )
 


### PR DESCRIPTION
## Summary
- accept both /saxo_login and /login_saxo commands in the Telegram webhook
- mention the new alias in help and error messaging
- cover the alias with a dedicated webhook test

## Testing
- pytest tests/test_telegram_login.py

------
https://chatgpt.com/codex/tasks/task_e_68cb17855eb8832f8b1ae261c90b80af